### PR TITLE
Increment build number for Linux long prefix build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - gvconfig_libdir.patch  # [unix]
 
 build:
-  number: 2
+  number: 3
   detect_binary_files_with_prefix: True  # [unix]
 
 requirements:


### PR DESCRIPTION
The last build on linux did not produce a long prefix build as the `pango` package was limited to a short prefix.  With a long prefix version of the package now available it should be possible to build graphviz with a a long prefix.