### PR TITLE
Update windows version with lib files instead of DLLs

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 :: Move needed library files
 mkdir %LIBRARY_LIB%\graphviz
-xcopy /S %SRC_DIR%\lib\release\dll  %LIBRARY_LIB%\graphviz
+xcopy /S %SRC_DIR%\lib\release\lib  %LIBRARY_LIB%\graphviz
 mkdir %LIBRARY_INC%\graphviz
 xcopy /S %SRC_DIR%\include\graphviz  %LIBRARY_INC%\graphviz
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - gvconfig_libdir.patch  # [unix]
 
 build:
-  number: 1010
+  number: 1011
   detect_binary_files_with_prefix: True  # [unix]
 
 requirements:


### PR DESCRIPTION
Turns out that it was the lib files that were needed when building the conda-forge package of pygraphviz