### PR TITLE
Bring back .bat wrappers (and put them in Scripts)

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,8 @@
+:: Primary build
+set _gz_builddir=%SRC_DIR%\build
 cmake -S%SRC_DIR% ^
-      -Bbuild ^
       -GNinja ^
+      -B%_gz_builddir% ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%LIBRARY_LIB% ^
@@ -9,3 +11,22 @@ if errorlevel 1 exit 1
 
 cmake --build build -- install
 if errorlevel 1 exit 1
+
+
+:: Reinstall into a temporary directory to gather names of execs
+set _gz_installdir=%SRC_DIR%\install
+cmake -Wno-dev -DCMAKE_INSTALL_PREFIX=%_gz_installdir% %_gz_builddir%
+if errorlevel 1 exit 1
+
+cmake --build %_gz_builddir% -- install
+if errorlevel 1 exit 1
+
+
+:: Setup wrappers for backwards compatibility
+if not exist "%PREFIX%\Scripts" mkdir %PREFIX%\Scripts
+cd %PREFIX%\Scripts
+for /r "%_gz_installdir%\bin" %%f in (*.exe) do (
+    echo @echo off > %%~nf.bat
+    echo %%~dp0.\..\Library\bin\%%~nf.exe %%* >> %%~nf.bat
+    if errorlevel 1 exit 1
+)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     folder: ltdl_compat
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true  # [unix]
 
 requirements:

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -4,6 +4,9 @@ if errorlevel 1 exit 1
 dot -V
 if errorlevel 1 exit 1
 
+dot.bat -V
+if errorlevel 1 exit 1
+
 echo: | dot -v
 if errorlevel 1 exit 1
 


### PR DESCRIPTION
Projects like python-graphviz and pydot depend on them. We shouldn't
break users with old versions. The bump to 2.46.1 is supposed to be a
backwards compatible change for them.
```
(graphviz) C:\Users\Wani>where dot
C:\Users\Wani\Miniconda3\envs\graphviz\Library\bin\dot.exe
C:\Users\Wani\Miniconda3\envs\graphviz\Scripts\dot.bat
```
Having both doesn't seem to hurt anyone and the` .exe` one will be before
the `.bat` one in `PATH` anyway.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
