### PR TITLE
Quote path in batch file as well

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -27,6 +27,6 @@ if not exist "%PREFIX%\Scripts" mkdir %PREFIX%\Scripts
 cd %PREFIX%\Scripts
 for /r "%_gz_installdir%\bin" %%f in (*.exe) do (
     echo @echo off > %%~nf.bat
-    echo %%~dp0.\..\Library\bin\%%~nf.exe %%* >> %%~nf.bat
+    echo "%%~dp0.\..\Library\bin\%%~nf.exe" %%* >> %%~nf.bat
     if errorlevel 1 exit 1
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     folder: ltdl_compat
 
 build:
-  number: 3
+  number: 4
   detect_binary_files_with_prefix: true  # [unix]
 
 requirements:


### PR DESCRIPTION
Should prevent problems finding the Graphviz executables when using the legacy `.bat` files.

Should fix conda-forge/graphviz-feedstock#43

@jakirkham: As requested in https://github.com/conda-forge/graphviz-feedstock/pull/63#issuecomment-783599273. Please note that I do not use Windows or conda myself, so I did not test this. Hope you can have a critical look.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
