### PR TITLE
Fix 119 with Compiler Flags from Anaconda Build

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cairo:
 - '1'
 cdt_name:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 expat:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -43,3 +43,9 @@ zip_keys:
   - cxx_compiler_version
 zlib:
 - '1.2'
+build_platform:
+- linux-64
+CMAKE_CROSSCOMPILING_EMULATOR: 
+- /usr/bin/qemu-aarch64-static
+CROSSCOMPILING_EMULATOR: 
+- /usr/bin/qemu-aarch64-static

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cairo:
 - '1'
 cdt_arch:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 expat:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cairo:
 - '1'
 cdt_name:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 expat:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -39,3 +39,9 @@ zip_keys:
   - cxx_compiler_version
 zlib:
 - '1.2'
+build_platform:
+- linux-64
+CMAKE_CROSSCOMPILING_EMULATOR: 
+- /usr/bin/qemu-ppc64le-static
+CROSSCOMPILING_EMULATOR: 
+- /usr/bin/qemu-ppc64le-static

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cairo:
 - '1'
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 expat:
 - '2'
 fontconfig:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cairo:
 - '1'
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 expat:
 - '2'
 fontconfig:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,6 +13,11 @@ if [[ ${target_platform} =~ .*osx.* ]]; then
     _xtra_config_flags+=(--with-quartz)
 fi
 
+export CFLAGS="-Wall -g -m${ARCH} -pipe -O2 -fPIC"
+export CXXLAGS="${CFLAGS}"
+export CPPFLAGS="-I${PREFIX}/include"
+export LDFLAGS="-L${PREFIX}/lib"
+
 ./configure --prefix=$PREFIX \
             --disable-debug \
             --disable-java \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,12 +11,12 @@ declare -a _xtra_config_flags
 if [[ ${target_platform} =~ .*osx.* ]]; then
     export OBJC="${CC}"
     _xtra_config_flags+=(--with-quartz)
+else
+    export CFLAGS="-Wall -g -pipe -O2 -fPIC"
+    export CXXLAGS="${CFLAGS}"
+    export CPPFLAGS="-I${PREFIX}/include"
+    export LDFLAGS="-L${PREFIX}/lib"
 fi
-
-export CFLAGS="-Wall -g -pipe -O2 -fPIC"
-export CXXLAGS="${CFLAGS}"
-export CPPFLAGS="-I${PREFIX}/include"
-export LDFLAGS="-L${PREFIX}/lib"
 
 ./configure --prefix=$PREFIX \
             --disable-debug \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,7 +13,7 @@ if [[ ${target_platform} =~ .*osx.* ]]; then
     _xtra_config_flags+=(--with-quartz)
 fi
 
-export CFLAGS="-Wall -g -m${ARCH} -pipe -O2 -fPIC"
+export CFLAGS="-Wall -g -pipe -O2 -fPIC"
 export CXXLAGS="${CFLAGS}"
 export CPPFLAGS="-I${PREFIX}/include"
 export LDFLAGS="-L${PREFIX}/lib"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     folder: ltdl_compat
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true  # [unix]
 
 requirements:

--- a/recipe/recipe-scripts-license.txt
+++ b/recipe/recipe-scripts-license.txt
@@ -1,0 +1,27 @@
+BSD-3-Clause license
+Copyright (c) 2015-2022, conda-forge contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -16,6 +16,9 @@ if errorlevel 1 exit 1
 neato -?
 if errorlevel 1 exit 1
 
+gvpack -v < NUL
+if errorlevel 1 exit 1
+
 for %%t in (png, pdf, svg, tiff, jpeg) do (
     dot -T%%t -o sample.%%t sample.dot
     if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -7,6 +7,7 @@ dot -v < /dev/null
 fdp -V
 sfdp -V
 neato -?
+gvpack -v < /dev/null
 
 dot -T? || true
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x ] Bumped the build number (if the version is unchanged)
* [x ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Hopefully closing #119. I added the compiler flags from the anaconda graphviz build. `-fPIC` in particular seems a plausible source of the fix. https://github.com/conda-archive/conda-recipes/blob/main/graphviz/build.sh

I've confirmed that gvpack now works in build.

<!--
Please add any other relevant info below:
-->
